### PR TITLE
Can not display certificate information when using SNI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -34,8 +34,6 @@ const cli = meow(`
 const command = cli.input[0],
       url = cli.input[1];
 
-console.log(cli.flags)
-
 if (cli.input.length === 0) {
   console.error(logSymbols.error, chalk.red('Input required'));
   process.exit(1);

--- a/cli.js
+++ b/cli.js
@@ -11,21 +11,30 @@ const page = require('page-data'),
 
 const cli = meow(`
     Usage
-      $ page <command> <url>
+      $ page <command> <url> <options>
 
     Command
       status  - page http GET response
       tls     - tls information (subject, issuer, valid term)
       meta    - meta information ( title, keyword, description )
 
+    tls Options
+      --servername -n, Servername
+
     Examples
       $ page state http:\/\/example.com
       $ page tls https:\/\/example.com
       $ page meta http:\/\/example.com
-`);
+`, {
+  alias: {
+    n: 'servername'
+  }
+});
 
 const command = cli.input[0],
       url = cli.input[1];
+
+console.log(cli.flags)
 
 if (cli.input.length === 0) {
   console.error(logSymbols.error, chalk.red('Input required'));
@@ -128,7 +137,11 @@ switch(command) {
     break;
 
   case 'tls':
-    page.tls(url)
+    let options = {}
+    if (cli.flags['servername']) {
+      options['servername'] = cli.flags['servername']
+    }
+    page.tls(url, options)
     .then(data => {
       tlsStout(data);
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "page-data-cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "simple page data get client tool cli",
   "main": "cli.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -36,7 +36,7 @@ test.cb('.tls()', t => {
   });
 
   const readStdOut = new Promise((resolve, reject) => {
-    execa.shell('node cli.js tls https://example.com').then(res => {
+    execa.shell('node cli.js tls https://example.com -n=example.com').then(res => {
       result = res
       resolve(res);
     })


### PR DESCRIPTION
### Summary

Fix to display certificate information when certificate was using Server Name Indication(SNI)

### Other Information

page-data `tls()` with option `servername`

### using

```sh
page tls https://example.com --servername=example.com
page tls https://example.com -n=example.com
```
